### PR TITLE
Add Alpine Linux package to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,16 @@ The time you worked is divided by 5, and that's the break time you'll take. E.g,
 
 The only official distribution format for Flowtime is the Flatpak package available on Flathub. Click on the banner on the top of this README.md to go to Flowtime's Flathub page. Any other unofficial distribution format that might be available is highly disencouraged.
 
-### AUR
+### Native Packages / Ports
 
-There's third-party, unofficial AUR packages:
+There exist some third party, distribution specific, packages:
 
-| Package        | Mantainer    |
-| -------------- | ------------ |
-| `flowtime`     | igor-dyatlov |
-| `flowtime-git` | igor-dyatlov |
+| Distribution        | Package name    | Mantainer       |
+| ------------------- | --------------- | --------------- |
+| Alpine Linux        | `flowtime`      | [chereskata](https://gitlab.alpinelinux.org/chereskata) |
+| Arch Linux (AUR)    | `flowtime`      | igor-dyatlov    |
+| Arch Linux (AUR)    | `flowtime-git`  | igor-dyatlov    |
+
 
 ### Building from source
 


### PR DESCRIPTION
I have packaged the awesome `flowtime` program for [Alpine Linux](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/flowtime).

So to let other users know, i edited the AUR table to contain infos for multiple distros.

Thank you and have a great day!
Krassy Boykinov